### PR TITLE
Config.plist format error

### DIFF
--- a/clover/config.plist
+++ b/clover/config.plist
@@ -437,7 +437,7 @@
 		<key>BoardManufacturer</key>
 		<string>Apple Inc.</string>
 		<key>BoardSerialNumber</key>
-		<string>C0xxxxxxxxxxxxxxx</string<
+		<string>C0xxxxxxxxxxxxxxx</string>
 		<key>BoardType</key>
 		<integer>10</integer>
 		<key>ChassisAssetTag</key>


### PR DESCRIPTION
The config.plist contains an error which prevents it from loading it properly in Clover. 