### PR TITLE
Updated config.plist

### DIFF
--- a/clover/config.plist
+++ b/clover/config.plist
@@ -390,7 +390,7 @@
 				ADIAAAAOAAAAAAAAAP////8=
 				</data>
 				<key>MatchOS</key>
-				<string>10.12</string>
+				<string>10.13</string>
 				<key>Name</key>
 				<string>AppleIntelFramebufferAzul</string>
 				<key>Replace</key>


### PR DESCRIPTION
MatchOS updated to 10.13 in the KextsToPatch section to re-enable AppleIntelFramebufferAzul patch